### PR TITLE
case sensitive adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-> ## Viper v2 feedback
-> Viper is heading towards v2 and we would love to hear what _**you**_ would like to see in it. Share your thoughts here: https://forms.gle/R6faU74qPRPAzchZ9
->
-> **Thank you!**
-
 ![Viper](.github/logo.png?raw=true)
 
 [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#configuration)
@@ -77,9 +72,8 @@ Viper uses the following precedence order. Each item takes precedence over the i
  * key/value store
  * default
 
-**Important:** Viper configuration keys are case insensitive.
-There are ongoing discussions about making that optional.
-
+Viper configuration keys are case insensitive by default. They can be made case
+sensitive with `viper.SetKeysCaseSensitivity(true)`.
 
 ## Putting Values into Viper
 
@@ -842,18 +836,6 @@ application foundation needs.
 ### Why is it called “Cobra”?
 
 Is there a better name for a [commander](http://en.wikipedia.org/wiki/Cobra_Commander)?
-
-### Does Viper support case sensitive keys?
-
-**tl;dr:** No.
-
-Viper merges configuration from various sources, many of which are either case insensitive or uses different casing than the rest of the sources (eg. env vars).
-In order to provide the best experience when using multiple sources, the decision has been made to make all keys case insensitive.
-
-There has been several attempts to implement case sensitivity, but unfortunately it's not that trivial. We might take a stab at implementing it in [Viper v2](https://github.com/spf13/viper/issues/772), but despite the initial noise, it does not seem to be requested that much.
-
-You can vote for case sensitivity by filling out this feedback form: https://forms.gle/R6faU74qPRPAzchZ9
-
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Viper uses the following precedence order. Each item takes precedence over the i
  * default
 
 Viper configuration keys are case insensitive by default. They can be made case
-sensitive with `viper.SetKeysCaseSensitivity(true)`.
+sensitive with `viper.SetKeysCaseSensitive(true)`.
 
 ## Putting Values into Viper
 
@@ -836,6 +836,13 @@ application foundation needs.
 ### Why is it called “Cobra”?
 
 Is there a better name for a [commander](http://en.wikipedia.org/wiki/Cobra_Commander)?
+
+### Does Viper support case-sensitive keys?
+
+**tl;dr:** Yes.
+
+Keys are case-insensitive by default. They can be made case-sensitive with
+`viper.SetKeysCaseSensitive(true)`.
 
 ## Troubleshooting
 

--- a/viper_test.go
+++ b/viper_test.go
@@ -1988,6 +1988,77 @@ R = 6
 	}
 }
 
+func TestCaseSensitive(t *testing.T) {
+	for _, config := range []struct {
+		typ     string
+		content string
+	}{
+		{"yaml", `
+aBcD: 1
+eF:
+  gH: 2
+  iJk: 3
+  Lm:
+    nO: 4
+    P:
+      Q: 5
+      R: 6
+`},
+		{"json", `{
+  "aBcD": 1,
+  "eF": {
+    "iJk": 3,
+    "Lm": {
+      "P": {
+        "Q": 5,
+        "R": 6
+      },
+      "nO": 4
+    },
+    "gH": 2
+  }
+}`},
+		{"toml", `aBcD = 1
+[eF]
+gH = 2
+iJk = 3
+[eF.Lm]
+nO = 4
+[eF.Lm.P]
+Q = 5
+R = 6
+`},
+	} {
+		doTestCaseSensitive(t, config.typ, config.content)
+	}
+}
+
+func doTestCaseSensitive(t *testing.T, typ, config string) {
+	Reset()
+	SetConfigType(typ)
+
+	// Turn on case sensitivity.
+	SetKeysCaseSensitive(true)
+	r := strings.NewReader(config)
+	if err := unmarshalReader(r, v.config); err != nil {
+		panic(err)
+	}
+
+	Set("RfD", true)
+	assert.Equal(t, nil, Get("rfd"))
+	assert.Equal(t, true, Get("RfD"))
+	assert.Equal(t, 0, cast.ToInt(Get("abcd")))
+	assert.Equal(t, 1, cast.ToInt(Get("aBcD")))
+	assert.Equal(t, 0, cast.ToInt(Get("ef.gh")))
+	assert.Equal(t, 2, cast.ToInt(Get("eF.gH")))
+	assert.Equal(t, 0, cast.ToInt(Get("ef.ijk")))
+	assert.Equal(t, 3, cast.ToInt(Get("eF.iJk")))
+	assert.Equal(t, 0, cast.ToInt(Get("ef.lm.no")))
+	assert.Equal(t, 4, cast.ToInt(Get("eF.Lm.nO")))
+	assert.Equal(t, 0, cast.ToInt(Get("ef.lm.p.q")))
+	assert.Equal(t, 5, cast.ToInt(Get("eF.Lm.P.Q")))
+}
+
 func TestCaseInsensitiveSet(t *testing.T) {
 	Reset()
 	m1 := map[string]interface{}{


### PR DESCRIPTION
Viper has opted to not support case-sensitive keys (https://github.com/spf13/viper#does-viper-support-case-sensitive-keys):

> Does Viper support case sensitive keys?
> tl;dr: No.
> 
> Viper merges configuration from various sources, many of which are either case insensitive or uses different casing than the rest of the sources (eg. env vars). In order to provide the best experience when using multiple sources, the decision has been made to make all keys case insensitive.
> 
> There has been several attempts to implement case sensitivity, but unfortunately it's not that trivial. We might take a stab at implementing it in Viper v2, but despite the initial noise, it does not seem to be requested that much.
> 
> You can vote for case sensitivity by filling out this feedback form: https://forms.gle/R6faU74qPRPAzchZ9

This PR applies changes described in a candidate PR (https://github.com/spf13/viper/pull/635) to optionally unlock this functionality.